### PR TITLE
feat: migrate settings to Obsidian 1.13 API

### DIFF
--- a/scripts/vitest-config.ts
+++ b/scripts/vitest-config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vitest/config';
 
 const SHARED_EXCLUDE = ['node_modules', 'dist'];
+const NO_WEBSTORAGE_EXEC_ARGV = process.allowedNodeEnvironmentFlags.has(
+    '--webstorage'
+  )
+  ? ['--no-webstorage']
+  : [];
 const BIG_TIMEOUT_IN_MILLISECONDS = 30_000;
 const ANDROID_TIMEOUT_IN_MILLISECONDS = 60_000;
 const HOOK_TIMEOUT_MULTIPLIER = 4;
@@ -36,7 +41,7 @@ export const config = defineConfig({
         test: {
           environment: 'jsdom',
           exclude: [...SHARED_EXCLUDE, 'src/**/*.integration.test.ts'],
-          execArgv: ['--no-webstorage'],
+          execArgv: NO_WEBSTORAGE_EXEC_ARGV,
           include: ['src/**/*.test.ts'],
           name: 'unit-tests',
           server: {

--- a/src/plugin-settings-tab.test.ts
+++ b/src/plugin-settings-tab.test.ts
@@ -1,6 +1,8 @@
 import type { Plugin } from 'obsidian';
 import type { PluginSettingsComponentBase } from 'obsidian-dev-utils/obsidian/components/plugin-settings-component';
 
+import { requireApiVersion } from 'obsidian';
+import { noopAsync } from 'obsidian-dev-utils/function';
 import { strictProxy } from 'obsidian-dev-utils/strict-proxy';
 import {
   describe,
@@ -12,6 +14,11 @@ import {
 import type { PluginSettings } from './plugin-settings.ts';
 
 import { PluginSettingsTab } from './plugin-settings-tab.ts';
+
+vi.mock('obsidian', async (importOriginal) => ({
+  ...await importOriginal<typeof import('obsidian')>(),
+  requireApiVersion: vi.fn(() => true)
+}));
 
 describe('PluginSettingsTab', () => {
   it('should display two toggle settings bound to the correct properties', () => {
@@ -59,5 +66,46 @@ describe('PluginSettingsTab', () => {
     expect(bindSpy).toHaveBeenCalledTimes(2);
     expect(bindSpy.mock.calls[0]?.[0].propertyName).toBe('shouldAutomaticallyRefreshBacklinkPanels');
     expect(bindSpy.mock.calls[1]?.[0].propertyName).toBe('shouldShowProgressBarOnLoad');
+  });
+
+  it('should expose declarative settings and persist control changes', async () => {
+    const saveToFile = vi.fn(() => noopAsync());
+    const setProperty = vi.fn(() => Promise.resolve(''));
+    const settings = {
+      shouldAutomaticallyRefreshBacklinkPanels: false,
+      shouldShowProgressBarOnLoad: true
+    };
+    const pluginSettingsComponent = strictProxy<PluginSettingsComponentBase<PluginSettings>>({
+      saveToFile,
+      setProperty,
+      settingsState: {
+        effectiveValues: settings,
+        inputValues: settings,
+        validationMessages: {
+          shouldAutomaticallyRefreshBacklinkPanels: '',
+          shouldShowProgressBarOnLoad: ''
+        }
+      }
+    });
+    const plugin = strictProxy<Plugin>({ app: {} });
+    const tab = new PluginSettingsTab({ plugin, pluginSettingsComponent });
+
+    expect(tab.getSettingDefinitions()).toMatchObject([
+      { name: 'Should automatically refresh backlink panels' },
+      { name: 'Should show progress bar on load' }
+    ]);
+    expect(tab.getControlValue('shouldShowProgressBarOnLoad')).toBe(true);
+    expect(tab.getControlValue('unknown')).toBeUndefined();
+
+    await tab.setControlValue('shouldShowProgressBarOnLoad', false);
+    expect(setProperty).toHaveBeenCalledWith('shouldShowProgressBarOnLoad', false);
+    expect(saveToFile).toHaveBeenCalledOnce();
+
+    await tab.setControlValue('shouldShowProgressBarOnLoad', 'false');
+    await tab.setControlValue('unknown', false);
+    expect(setProperty).toHaveBeenCalledOnce();
+
+    vi.mocked(requireApiVersion).mockReturnValueOnce(false);
+    expect(tab.getSettingDefinitions()).toEqual([]);
   });
 });

--- a/src/plugin-settings-tab.ts
+++ b/src/plugin-settings-tab.ts
@@ -1,4 +1,10 @@
-import { PluginSettingsTabBase } from 'obsidian-dev-utils/obsidian/plugin/plugin-settings-tab';
+import type { SettingDefinitionItem } from 'obsidian';
+
+import { requireApiVersion } from 'obsidian';
+import {
+  PluginSettingsTabBase,
+  SAVE_TO_FILE_CONTEXT
+} from 'obsidian-dev-utils/obsidian/plugin/plugin-settings-tab';
 import { SettingEx } from 'obsidian-dev-utils/obsidian/setting-ex';
 
 import type { PluginSettings } from './plugin-settings.ts';
@@ -26,5 +32,49 @@ export class PluginSettingsTab extends PluginSettingsTabBase<PluginSettings> {
           valueComponent: toggle
         });
       });
+  }
+
+  public override getControlValue(key: string): unknown {
+    if (key === 'shouldAutomaticallyRefreshBacklinkPanels' || key === 'shouldShowProgressBarOnLoad') {
+      return this.pluginSettingsComponent.settingsState.inputValues[key];
+    }
+
+    return undefined;
+  }
+
+  public override getSettingDefinitions(): SettingDefinitionItem<keyof PluginSettings>[] {
+    if (!requireApiVersion('1.13.0')) {
+      return [];
+    }
+
+    return [
+      {
+        control: {
+          key: 'shouldAutomaticallyRefreshBacklinkPanels',
+          type: 'toggle'
+        },
+        desc: 'Whether to refresh the backlink panels automatically when a note is saved.',
+        name: 'Should automatically refresh backlink panels'
+      },
+      {
+        control: {
+          key: 'shouldShowProgressBarOnLoad',
+          type: 'toggle'
+        },
+        desc: 'Whether to show progress bar on load.',
+        name: 'Should show progress bar on load'
+      }
+    ];
+  }
+
+  public override async setControlValue(key: string, value: unknown): Promise<void> {
+    if (typeof value !== 'boolean') {
+      return;
+    }
+
+    if (key === 'shouldAutomaticallyRefreshBacklinkPanels' || key === 'shouldShowProgressBarOnLoad') {
+      await this.pluginSettingsComponent.setProperty(key, value);
+      await this.pluginSettingsComponent.saveToFile(SAVE_TO_FILE_CONTEXT);
+    }
   }
 }


### PR DESCRIPTION
### Summary

- Add Obsidian 1.13 declarative definitions for the two existing toggles and persist control changes through the existing settings component, while retaining the legacy settings renderer for older supported versions.
- Extend the settings-tab tests to cover definitions, reads and writes, invalid values, and the pre-1.13 guard.
- Pass Vitest's `--no-webstorage` worker flag only when the active Node runtime supports it.

### Testing

- [x] All 118 Vitest tests pass.
- [x] Typecheck, lint, and production build pass.
- [ ] `npm run format:check`
- [ ] `npm run spellcheck`